### PR TITLE
Add cellStyle and cellRender props

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,17 @@ ReactDOM.render(
 
 |Name |Type|Description|Default Value|
 |---|---|---|---|
-|background|string|The base color for the heatmap|#329fff|
-|height|number|Height of each cell of the heatmap in px|30|
-|onClick|function|adds an handler to cell click|undefined|
-|squares|boolean|cells become squares if true|false|
-|xLabelWidth|number|Width of the x label area in pixel|60|
-|yLabelTextAlign|string|text alignment of the yLabels|right|
-|xLabelsLocation|string|Location of y labels. It can be top or bottom|top|
+|background|string|The base color for the heatmap|`"#329fff"`|
+|height|number|Height of each cell of the heatmap in px|`30`|
+|onClick|function|adds an handler to cell click|`undefined`|
+|squares|boolean|cells become squares if true|`false`|
+|xLabelWidth|number|Width of the x label area in pixel|`60`|
+|yLabelTextAlign|string|text alignment of the yLabels|`"right"`|
+|xLabelsLocation|string|Location of y labels. It can be top or bottom|`"top"`|
 |xLabelsVisibility|`[boolean]`|Array of bool conveying which x labels to display. For ex: `[true, false, true, false]` means the 1st and the 3rd labels will be displayed and the 2nd and 4th will be hidden||
 |unit|string|unit to display next to the value on hover||
+|cellRender|function|render custom content per cell|`<span>&nbsp;</span>`|
+|cellStyle|function|custom cell style - useful for using own colour scheme|`{ background, opacity }`|
 
 
 ### For developers

--- a/src/DataGrid.jsx
+++ b/src/DataGrid.jsx
@@ -15,6 +15,8 @@ const DataGrid = ({
   onClick,
   cursor,
   squares,
+  cellRender,
+  cellStyle,
 }) => {
   const flatArray = data.reduce((i, o) => [...o, ...i], []);
   const max = Math.max(...flatArray);
@@ -34,24 +36,29 @@ const DataGrid = ({
               {displayYLabels && y}
             </div>
           </FixedBox>
-          {xLabels.map((x, xi) => (
-            <div
-              onClick={onClick.bind(this, xi, yi)}
-              title={`${data[yi][xi]} ${unit}`}
-              key={`${x}_${y}`}
-              style={{
-                cursor: `${cursor}`,
-                background,
-                margin: "1px 1px 0 0",
-                height,
-                width: squares ? `${height}px` : undefined,
-                flex: squares ? "none" : 1,
-                opacity: (data[yi][xi] - min) / (max - min) || 0,
-              }}
-            >
-              &nbsp;
-            </div>
-          ))}
+          {xLabels.map((x, xi) => {
+            const value = data[yi][xi];
+            const style = Object.assign({}, cellStyle(background, value, min, max, data, xi, yi), {
+              cursor: `${cursor}`,
+              margin: "1px 1px 0 0",
+              height,
+              width: squares ? `${height}px` : undefined,
+              flex: squares ? "none" : 1,
+              textAlign: "center",
+            })
+            return (
+              <div
+                onClick={onClick.bind(this, xi, yi)}
+                title={value && `${value} ${unit}`}
+                key={`${x}_${y}`}
+                style={style}
+              >
+                <div style={{ paddingTop: `${height / 3.7}px` }}>
+                  {cellRender(value)}
+                </div>
+              </div>
+            )
+          })}
         </div>
       ))}
     </div>
@@ -75,6 +82,8 @@ DataGrid.propTypes = {
   onClick: PropTypes.func,
   cursor: PropTypes.string,
   squares: PropTypes.bool,
+  cellRender: PropTypes.func.isRequired,
+  cellStyle: PropTypes.func.isRequired,
 };
 
 DataGrid.defaultProps = {

--- a/src/DataGrid.jsx
+++ b/src/DataGrid.jsx
@@ -49,7 +49,7 @@ const DataGrid = ({
             return (
               <div
                 onClick={onClick.bind(this, xi, yi)}
-                title={value && `${value} ${unit}`}
+                title={(value || value === 0) && `${value} ${unit}`}
                 key={`${x}_${y}`}
                 style={style}
               >

--- a/src/HeatMap.jsx
+++ b/src/HeatMap.jsx
@@ -17,6 +17,8 @@ function HeatMap({
   displayYLabels,
   onClick,
   squares,
+  cellRender,
+  cellStyle,
 }) {
   let cursor = "";
   if (onClick !== undefined) {
@@ -49,6 +51,8 @@ function HeatMap({
           onClick,
           cursor,
           squares,
+          cellRender,
+          cellStyle,
         }}
       />
       {xLabelsLocation === "bottom" && xLabelsEle}
@@ -74,6 +78,8 @@ HeatMap.propTypes = {
   unit: PropTypes.string,
   onClick: PropTypes.func,
   squares: PropTypes.bool,
+  cellRender: PropTypes.func,
+  cellStyle: PropTypes.func,
 };
 
 HeatMap.defaultProps = {
@@ -87,6 +93,11 @@ HeatMap.defaultProps = {
   displayYLabels: true,
   onClick: undefined,
   squares: false,
+  cellRender: () => <span>&nbsp;</span>,
+  cellStyle: (background, value, min, max) => ({
+    background,
+    opacity: (value - min) / (max - min) || 0,
+  })
 };
 
 export default HeatMap;


### PR DESCRIPTION
Two new props:
* `cellStyle` - override background/opacity CSS & add extra cell styling
* `cellRender` - override default `&nbsp` value of each cell

## cellRender Example
```
<HeatMap
    xLabels={xLabels}
    yLabels={yLabels}
    xLabelsLocation={"bottom"}
    xLabelsVisibility={xLabelsVisibility}
    xLabelWidth={50}
    data={data}
    squares
    onClick={(x, y) => alert(`Clicked ${x}, ${y}`)}
    cellRender={value => value && `${value}`}
/>
```

## cellStyle Example
Allows users to define their own custom colour schemes, the following example is a retention chart where each row uses the first column as a base for calculating an alpha rgb value:
```
<HeatMap
    xLabels={['1', '2', '3', '4', '5']}
    yLabels={['2018-01', '2018-02', '2018-03', '2018-04', '2018-05']}
    xLabelsLocation={"bottom"}
    xLabelsVisibility={xLabelsVisibility}
    xLabelWidth={60}
    height={50}
    data={[
      [100, 85, 80, 75, 70],
      [100, 70, 70, 70, null],
      [100, 60, 40, null, null],
      [100, 20, null, null, null],
      [100, null, null, null, null],
    ]}
    squares
    cellStyle={(background, value, min, max, data, x, y) => ({
      background: `rgb(66, 86, 244, ${1 - (data[y][0] - value) / data[y][0]})`,
    })}
    cellRender={value => value && `${value}%`}
/>
```
<img width="386" alt="screen shot 2018-09-18 at 11 41 18" src="https://user-images.githubusercontent.com/7195374/45685198-82b4fb00-bb40-11e8-9be4-04d54190ead5.png">
