### PR TITLE
 Parameterize cell title maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A React component for heatmap in grid layout using `div`.
 yarn add react-heatmap-grid
 ```
 
-or 
+or
 
 ```
 npm install react-heatmap-grid --save
@@ -26,13 +26,13 @@ npm install react-heatmap-grid --save
 
 ## Usage
 
-**Mandatory fields** 
+**Mandatory fields**
 
 |Name |Type|Sample|
 |---|---|---|
 |`xLabels`|Array of string|`['1am', '2am', '3am']`|
 |`yLabels`|Array of string|`['Sun', 'Mon']`|
-|`data`|2D Array of numbers having `yLabels.length` rows and `xLabels.length` rows|`[[2,3,5][5,6,9]]`| 
+|`data`|2D Array of numbers having `yLabels.length` rows and `xLabels.length` rows|`[[2,3,5][5,6,9]]`|
 
 ```javascript
 const xLabels = new Array(24).fill(0).map((_, i) => `${i}`);
@@ -68,6 +68,7 @@ ReactDOM.render(
 |unit|string|Unit to display next to the value on hover||
 |cellRender|function|Render custom content in cell|`() => null`|
 |cellStyle|function|To set custom cell style. It is useful for using own colour scheme||
+|title|function|To render custom title in each cell|`${value} ${unit}`|
 
 Example
 ```javascript
@@ -101,6 +102,7 @@ ReactDOM.render(
       fontSize: "11px",
     })}
     cellRender={value => value && `${value}%`}
+    title={(value, unit) => `$value`}
   />,
   document.getElementById("app")
 );

--- a/src/DataGrid.jsx
+++ b/src/DataGrid.jsx
@@ -18,10 +18,12 @@ const DataGrid = ({
   squares,
   cellRender,
   cellStyle,
+  title
 }) => {
   const flatArray = data.reduce((i, o) => [...o, ...i], []);
   const max = Math.max(...flatArray);
   const min = Math.min(...flatArray);
+
   return (
     <div>
       {yLabels.map((y, yi) => (
@@ -54,7 +56,7 @@ const DataGrid = ({
             return (
               <div
                 onClick={onClick.bind(this, xi, yi)}
-                title={(value || value === 0) && `${value} ${unit}`}
+                title={title(value, unit)}
                 key={`${xi}_${yi}`}
                 style={style}
               >
@@ -90,6 +92,7 @@ DataGrid.propTypes = {
   squares: PropTypes.bool,
   cellRender: PropTypes.func.isRequired,
   cellStyle: PropTypes.func.isRequired,
+  title: PropTypes.func
 };
 
 DataGrid.defaultProps = {
@@ -97,7 +100,7 @@ DataGrid.defaultProps = {
   cursor: "",
   onClick: () => {},
   squares: false,
+  title: (value, unit) => (value || value === 0) && `${value} ${unit}`
 };
 
 export default DataGrid;
-

--- a/src/HeatMap.jsx
+++ b/src/HeatMap.jsx
@@ -20,6 +20,7 @@ function HeatMap({
   squares,
   cellRender,
   cellStyle,
+  title
 }) {
   let cursor = "";
   if (onClick !== undefined) {
@@ -56,6 +57,7 @@ function HeatMap({
           squares,
           cellRender,
           cellStyle,
+          title
         }}
       />
       {xLabelsLocation === "bottom" && xLabelsEle}
@@ -84,6 +86,7 @@ HeatMap.propTypes = {
   squares: PropTypes.bool,
   cellRender: PropTypes.func,
   cellStyle: PropTypes.func,
+  title: PropTypes.func
 };
 
 HeatMap.defaultProps = {
@@ -102,8 +105,7 @@ HeatMap.defaultProps = {
   cellStyle: (background, value, min, max) => ({
     background,
     opacity: (value - min) / (max - min) || 0,
-  }),
+  })
 };
 
 export default HeatMap;
-

--- a/test/DataGrid.spec.jsx
+++ b/test/DataGrid.spec.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import 'raf/polyfill';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import DataGrid from '../src/DataGrid';
+
+configure({ adapter: new Adapter() });
+
+const defaultProps = {
+  xLabels: ['x'],
+  yLabels: ['y'],
+  data: [[0]],
+  height: 1,
+  background: '#000000',
+  xLabelWidth: 1,
+  yLabelWidth: 1,
+  xLabelTextAlign: 'top',
+  yLabelTextAlign: 'left',
+  unit: '$',
+  cellRender: () => null,
+  cellStyle: () => {},
+  width: 1
+}
+
+test('DataGrid renders a title from the provided title function', () => {
+  const dataGrid = shallow(
+    <DataGrid {...defaultProps} title={(value) => `CUSTOM_TITLE`} />
+  );
+
+  expect(dataGrid.find({title: 'CUSTOM_TITLE'})).toHaveLength(1);
+})
+
+test('DataGrid renders a default title when no title function is provided', () => {
+  const dataGrid = shallow(
+      <DataGrid {...defaultProps} />
+  );
+
+  expect(dataGrid.find({title: '0 $'})).toHaveLength(1);
+})


### PR DESCRIPTION
#64 

Allow heatmap users to provide their own way of creating the title attribute for
each cell. The old title is still used as a default.